### PR TITLE
clang-tidy: make the clang-tidy binary that is used configurable

### DIFF
--- a/source/code_checker/cli.d
+++ b/source/code_checker/cli.d
@@ -37,11 +37,23 @@ struct ConfigStaticCode {
 
 /// Configuration options only relevant for clang-tidy.
 struct ConfigClangTidy {
+    /// Checks to toggle on/off
     string[] checks;
+
+    /// Arguments to be baked into the checks parameter
     string[] options;
+
+    /// Argument to the filter parameter
     string headerFilter;
+
+    /// Apply fix hints.
     bool applyFixit;
+
+    /// Apply fix hints even though they result in errors.
     bool applyFixitErrors;
+
+    /// The clang-tidy binary to use.
+    string binary = "clang-tidy";
 }
 
 /// Configuration data for the compile_commands.json
@@ -147,6 +159,8 @@ struct Config {
         app.put(null);
 
         app.put("[clang_tidy]");
+        app.put("# clang-tidy binary to use");
+        app.put(format(`# binary = "%s"`, clangTidy.binary));
         app.put("# arguments to -header-filter");
         app.put(format(`header_filter = "%s"`, clangTidy.headerFilter));
         if (full) {
@@ -224,6 +238,7 @@ void parseCLI(string[] args, ref Config conf) @trusted {
 
         // dfmt off
         help_info = std.getopt.getopt(args,
+            "clang-tidy-bin", "clang-tidy binary to use", &conf.clangTidy.binary,
             "clang-tidy-fix", "apply suggested clang-tidy fixes", &conf.clangTidy.applyFixit,
             "clang-tidy-fix-errors", "apply suggested clang-tidy fixes even if they result in compilation errors", &conf.clangTidy.applyFixitErrors,
             "compile-db", "path to a compilationi database or where to search for one", &compile_dbs,

--- a/source/code_checker/engine/builtin/clang_tidy.d
+++ b/source/code_checker/engine/builtin/clang_tidy.d
@@ -46,6 +46,7 @@ class ClangTidy : BaseFixture {
         import code_checker.engine.builtin.clang_tidy_classification : filterSeverity;
 
         auto app = appender!(string[])();
+        app.put(env.clangTidy.binary);
 
         app.put("-p=.");
 
@@ -88,7 +89,7 @@ class ClangTidy : BaseFixture {
             app.put(c.data);
         }
 
-        tidyArgs ~= app.data;
+        tidyArgs = app.data;
     }
 
     /// Execute the analyzer.
@@ -241,7 +242,7 @@ void executeFixit(Environment env, string[] tidyArgs, ref Result result_) {
         files ~= cmd.absoluteFile;
     }
 
-    auto args = [ClangTidyConstants.bin] ~ tidyArgs ~ files.map!(a => cast(string) a).array;
+    auto args = tidyArgs ~ files.map!(a => cast(string) a).array;
     logger.tracef("run: %s", args);
 
     auto status = spawnProcess(args).wait;
@@ -322,18 +323,15 @@ void taskTidy(Tid owner, immutable TidyWork* work_) nothrow @trusted {
 }
 
 struct ClangTidyConstants {
-    static immutable bin = "clang-tidy";
     static immutable confFile = ".clang-tidy";
 }
 
 auto runClangTidy(string[] tidy_args, AbsolutePath[] fname) {
     import std.algorithm : copy;
-    import std.format : format;
     import std.array : appender;
     import code_checker.process;
 
     auto app = appender!(string[])();
-    app.put(ClangTidyConstants.bin);
     tidy_args.copy(app);
     fname.copy(app);
 


### PR DESCRIPTION
This is required for supporting windows because then the binary is
called something ending with ".exe".