### PR TITLE
Remove the minus points from the score when suppressing warnings

### DIFF
--- a/source/code_checker/engine/builtin/clang_tidy.d
+++ b/source/code_checker/engine/builtin/clang_tidy.d
@@ -144,7 +144,6 @@ void executeParallel(Environment env, string[] tidyArgs, ref Result result_) @sa
 
         // one point for each good file. This is to try and encourage good behaviour.
         result_.score += res.errors.score == 0 ? 1 : res.errors.score;
-        result_.supp += res.suppressedWarnings;
 
         if (res.clangTidyStatus != 0) {
             res.print;

--- a/source/code_checker/engine/registry.d
+++ b/source/code_checker/engine/registry.d
@@ -150,19 +150,14 @@ void log(TotalResult tres) {
 
     if (tres.status == Status.passed) {
         logger.info("Congratulations!!!");
-        logger.infof("Your code reached Quality Level %s", 1 + tres.score / 10);
     }
 
-    const string score = () {
-        if (tres.score < 0)
-            return tres.score.to!string.color(Color.red).mode(Mode.bold).toString;
-        return tres.score.to!string;
-    }();
+    string score() {
+        return tres.score < 0 ? tres.score.to!string.color(Color.red)
+            .mode(Mode.bold).toString : tres.score.to!string;
+    }
+
     logger.infof("You scored %s points", score);
-
-    if (tres.score < 0) {
-        logger.info("Sorry, your code needs a major rework to reach an acceptable quality level");
-    }
 }
 
 /// Input range over the analysers.

--- a/test/testdata/conf/gen_db_cmd/orig.json
+++ b/test/testdata/conf/gen_db_cmd/orig.json
@@ -2,6 +2,6 @@
     {
         "directory": ".",
         "arguments": ["g++", "-c", "empty.cpp", "-o", "empty.o"],
-        "file": "../empty.cpp"
+        "file": "./empty.cpp"
     }
 ]


### PR DESCRIPTION
This is to fix the problem where new files are added and the score is
reduced because they contains suppressions. This makes it impossible to
have a hook in a repo which blocks when the score is reduced.